### PR TITLE
#1062 DevStudio, вставляются некорректные теги для некоторых типов компонентов

### DIFF
--- a/plugins/ru.runa.gpd.form.ftl/src/ru/runa/gpd/formeditor/ftl/Component.java
+++ b/plugins/ru.runa.gpd.form.ftl/src/ru/runa/gpd/formeditor/ftl/Component.java
@@ -137,39 +137,32 @@ public class Component extends EventSupport implements IPropertySource {
     }
 
     @Override
+    //this method is a part of the algorithm
+    //return Freemarker expression ${type_name("param1",..)}
     public String toString() {
-        StringBuffer ftl = new StringBuffer();
-        ftl.append("${").append(type.getId()).append("(");
-        boolean first = true;
+        List<String> args=new ArrayList<String>();
         for (ComponentParameter parameter : type.getParameters()) {
-            if (!first) {
-                ftl.append(PARAMETERS_DELIM);
-            } else {
-                first = false;
-            }
             final boolean surroundWithBrackets = parameter.getType().isSurroundBrackets();
-            Object obj = null;
+            
+            //multiple type, by convention, is always the last and
+            //its items should be appended directly to the args list
             if (parameter.getType().isMultiple()) {
-                List<String> list = (List<String>) getParameterValue(parameter);
-                obj = Joiner.on(PARAMETERS_DELIM).join(Lists.transform(list, new Function<String, String>() {
-
-                    @Override
-                    public String apply(String string) {
-                        if (surroundWithBrackets) {
-                            return stringQuotation(string);
-                        }
-                        return string;
+                List<String> list = Lists.transform(
+                    (List<String>)getParameterValue(parameter),
+                    new Function<String, String>(){
+                       @Override
+                       public String apply(String string) {
+                           return surroundWithBrackets? stringQuotation(string): string;
+                       }
                     }
-                }));
-            } else {
-                obj = getParameterValue(parameter);
-                if (surroundWithBrackets) {
-                    obj = stringQuotation(obj);
-                }
+                );
+                args.addAll(list);
             }
-            ftl.append(obj);
+            else {
+                String s = getParameterValue(parameter).toString();
+                args.add(surroundWithBrackets? stringQuotation(s): s);
+            }
         }
-        ftl.append(")}");
-        return ftl.toString();
+        return "${"+type.getId()+"("+Joiner.on(PARAMETERS_DELIM).join(args)+")}";
     }
 }

--- a/plugins/ru.runa.gpd.form.ftl/src/ru/runa/gpd/formeditor/ftl/Component.java
+++ b/plugins/ru.runa.gpd.form.ftl/src/ru/runa/gpd/formeditor/ftl/Component.java
@@ -136,16 +136,18 @@ public class Component extends EventSupport implements IPropertySource {
         return String.format("\"%s\"", obj.toString().replaceAll("\"", "\\\\\""));
     }
 
+   /*
+    * Note: this method is the part of the algorithm, don't change the return format
+    * @return the Freemarker expression ${type_name("param1",..)}
+    **/
     @Override
-    //this method is a part of the algorithm
-    //return Freemarker expression ${type_name("param1",..)}
     public String toString() {
         List<String> args=new ArrayList<String>();
         for (ComponentParameter parameter : type.getParameters()) {
             final boolean surroundWithBrackets = parameter.getType().isSurroundBrackets();
             
-            //multiple type, by convention, is always the last and
-            //its items should be appended directly to the args list
+            //multiple type argument, by convention, is always the last one
+            //and its items should be appended directly to the args list
             if (parameter.getType().isMultiple()) {
                 List<String> list = Lists.transform(
                     (List<String>)getParameterValue(parameter),


### PR DESCRIPTION
Проблема возникала из-за тегов вида ${type("param1","param2",)}  (внимание на последнюю запятую). Причина - некорректное форматирование параметров с типом где multiple=true в методе 
ru.runa.gpd.formeditor.ftl.Component.toString() . Вставлялась лишняя запятая, которая ломала парсер шаблонизатора.
