### PR TITLE
Изменяем поведение таймера по двойном клике мышке на нем.

### DIFF
--- a/plugins/ru.runa.gpd/src/ru/runa/gpd/editor/graphiti/update/DoubleClickTimerFeature.java
+++ b/plugins/ru.runa.gpd/src/ru/runa/gpd/editor/graphiti/update/DoubleClickTimerFeature.java
@@ -3,11 +3,11 @@ package ru.runa.gpd.editor.graphiti.update;
 import com.google.common.base.Objects;
 import org.eclipse.graphiti.features.context.ICustomContext;
 import org.eclipse.swt.widgets.Display;
-import ru.runa.gpd.editor.graphiti.ChangeTimerActionFeature;
+import ru.runa.gpd.editor.graphiti.ChangeTimerDelayFeature;
 import ru.runa.gpd.editor.graphiti.UndoRedoUtil;
 import ru.runa.gpd.lang.model.Timer;
-import ru.runa.gpd.lang.model.TimerAction;
-import ru.runa.gpd.ui.dialog.TimerActionEditDialog;
+import ru.runa.gpd.ui.dialog.DurationEditDialog;
+import ru.runa.gpd.util.Duration;
 
 public class DoubleClickTimerFeature extends DoubleClickElementFeature {
 
@@ -18,16 +18,16 @@ public class DoubleClickTimerFeature extends DoubleClickElementFeature {
 
     @Override
     public void execute(ICustomContext context) {
-        Timer timer = (Timer) getBusinessObject(context);
-        TimerAction oldAction = timer.getAction();
-        TimerActionEditDialog dialog = new TimerActionEditDialog(timer.getProcessDefinition(), timer.getAction());
-        TimerAction result = (TimerAction) dialog.openDialog();
+    	Timer timer = (Timer) getBusinessObject(context);
+        Duration oldDelay = timer.getDelay();
+        DurationEditDialog dialog = new DurationEditDialog(timer.getProcessDefinition(), timer.getDelay());
+        Duration result = (Duration) dialog.openDialog();
         if (result != null) {
-            if (!Objects.equal(result, oldAction)) {
+        	if (!Objects.equal(result, oldDelay)) {
                 Display.getDefault().asyncExec(new Runnable() {
                     @Override
                     public void run() {
-                        UndoRedoUtil.executeFeature(new ChangeTimerActionFeature(timer, result));
+                    	UndoRedoUtil.executeFeature(new ChangeTimerDelayFeature(timer, result));
                     }
                 });
             }

--- a/plugins/ru.runa.gpd/src/ru/runa/gpd/editor/graphiti/update/DoubleClickTimerFeature.java
+++ b/plugins/ru.runa.gpd/src/ru/runa/gpd/editor/graphiti/update/DoubleClickTimerFeature.java
@@ -23,7 +23,7 @@ public class DoubleClickTimerFeature extends DoubleClickElementFeature {
         DurationEditDialog dialog = new DurationEditDialog(timer.getProcessDefinition(), timer.getDelay());
         Duration result = (Duration) dialog.openDialog();
         if (result != null) {
-        	if (!Objects.equal(result, oldDelay)) {
+            if (!Objects.equal(result, oldDelay)) {
                 Display.getDefault().asyncExec(new Runnable() {
                     @Override
                     public void run() {


### PR DESCRIPTION
Было: При двойном клике мышки на таймере открывались пареметры действия таймера.
Исправленно: При двойном клике мышки на таймере открываються параметры задердки.

Fix #2029