### PR TITLE
Add support for List(File) variables in attachments in SendEmailActionHandler

### DIFF
--- a/plugins/ru.runa.gpd/src/ru/runa/gpd/extension/handler/EmailConfigWizardPage.java
+++ b/plugins/ru.runa.gpd/src/ru/runa/gpd/extension/handler/EmailConfigWizardPage.java
@@ -341,7 +341,9 @@ public class EmailConfigWizardPage extends WizardPage implements MessageDisplay 
         private class AddSelectionAdapter extends LoggingSelectionAdapter {
             @Override
             protected void onSelection(SelectionEvent e) throws Exception {
-                List<String> fileVariableNames = delegable.getVariableNames(true, FileVariable.class.getName());
+                List<String> fileVariableNames = delegable.getVariableNames(true,
+                        FileVariable.class.getName(),
+                        List.class.getName() + Variable.FORMAT_COMPONENT_TYPE_START + FileVariable.class.getName() + Variable.FORMAT_COMPONENT_TYPE_END);
                 ChooseVariableNameDialog dialog = new ChooseVariableNameDialog(fileVariableNames);
                 String variableName = dialog.openDialog();
                 if (variableName != null) {


### PR DESCRIPTION
In SendEmailActionHandler configuration, variable selection dialog for attachments now displays variables with type List(File).

I was not able to test the functionality properly. The dialog behaves as expected, but I didn't have the setup to send a test email. I have traced the effects of the change in code, and the effects are pretty limited - variable names are simply serialized into XML.

That said, I don't quite understand what the `delegate` could be in this case. A possible problem is that different `Delegate`s have different implementations of `getVariableNames(boolean, String...)`, and only some implementations support querying for list element type which I used.