### PR TITLE
Bug #3985 Fix NPE in External Storage Handler

### DIFF
--- a/plugins/ru.runa.gpd.office/src/ru/runa/gpd/office/store/BaseCommonStorageHandlerCellEditorProvider.java
+++ b/plugins/ru.runa.gpd.office/src/ru/runa/gpd/office/store/BaseCommonStorageHandlerCellEditorProvider.java
@@ -147,14 +147,16 @@ public abstract class BaseCommonStorageHandlerCellEditorProvider extends XmlBase
                     new Label(this, SWT.NONE);
                 }
 
-                SwtUtils.createLink(this, Messages.getString("label.AddVar"), new LoggingHyperlinkAdapter() {
+                if (queryType != null) {
+	                SwtUtils.createLink(this, Messages.getString("label.AddVar"), new LoggingHyperlinkAdapter() {
 
-                    @Override
-                    protected void onLinkActivated(HyperlinkEvent e) throws Exception {
-                        model.constraints.add(new StorageConstraintsModel(StorageConstraintsModel.ATTR, queryType));
-                        buildFromModel();
-                    }
-                }).setLayoutData(new GridData(GridData.GRAB_HORIZONTAL | GridData.HORIZONTAL_ALIGN_END));
+	                    @Override
+	                    protected void onLinkActivated(HyperlinkEvent e) throws Exception {
+	                        model.constraints.add(new StorageConstraintsModel(StorageConstraintsModel.ATTR, queryType));
+	                        buildFromModel();
+	                    }
+	                }).setLayoutData(new GridData(GridData.GRAB_HORIZONTAL | GridData.HORIZONTAL_ALIGN_END));
+                }
                 new Label(this, SWT.NONE);
                 warning = new Label(this, SWT.NONE);
                 warning.setForeground(darkRed);


### PR DESCRIPTION
Problem:
When a query type wasn’t selected and the link “Add attribute” was clicked, a Null Pointer Exception happened.
It happened because the link creation has an “onLinkActivated” method which requires “queryType” as a parameter.

Solution:
I added not null check before the link creation. Now the link appears only after the query type is selected in the drop-down list.